### PR TITLE
refactor: Reduce the size of the container image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,22 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install additional OS packages and dev tools
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends git-core curl build-essential zsh fonts-powerline
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+    git-core \
+    curl \
+    build-essential \
+    zsh \
+    fonts-powerline
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get -y install gh
 
 # Install specific npm version
 RUN npm install -g npm@11.2.0

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ next-env.d.ts
 temp
 openapi.yaml
 examples
+tsconfig.tsbuildinfo

--- a/examples/docker-compose/basic/docker-compose.yaml
+++ b/examples/docker-compose/basic/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
         reservations:
           cpus: "0.25"
           memory: 256M
+    pull_policy: always
     restart: unless-stopped
 
   inference-gateway:
@@ -30,4 +31,5 @@ services:
         reservations:
           cpus: "0.1"
           memory: 100M
+    pull_policy: always
     restart: unless-stopped

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
+  reactStrictMode: true,
   images: {
     unoptimized: true,
   },
@@ -9,6 +11,6 @@ const nextConfig: NextConfig = {
     parallelServerBuildTraces: true,
     parallelServerCompiles: true,
   },
-}
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
## Summary

Reduce the size of the container image.

Also add `pull_policy` and set it to `always` to the docker-compose file in the example to ensure that the latest image is always pulled.
