### PR TITLE
rc: Fix - rename auth enabled environment variable for consistency with the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1-rc.1](https://github.com/inference-gateway/ui/compare/v0.6.0...v0.6.1-rc.1) (2025-04-24)
+
+### 🐛 Bug Fixes
+
+* Update environment variable from AUTH_ENABLED to ENABLE_AUTH for consistency with the backend ([19bbd5c](https://github.com/inference-gateway/ui/commit/19bbd5c9448d5dccaf94037473cd3023328e7765))
+
+### 🔧 Miscellaneous
+
+* Update comment in Session interface for clarity on ENABLE_AUTH usage ([8d177f3](https://github.com/inference-gateway/ui/commit/8d177f3033ee16886e4757360967fbbdcca54fd7))
+
 ## [0.6.0](https://github.com/inference-gateway/ui/compare/v0.5.0...v0.6.0) (2025-04-24)
 
 ### ✨ Features

--- a/charts/inference-gateway-ui/Chart.yaml
+++ b/charts/inference-gateway-ui/Chart.yaml
@@ -22,10 +22,10 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0"
+appVersion: "0.6.1-rc.1"

--- a/examples/kubernetes/Taskfile.yaml
+++ b/examples/kubernetes/Taskfile.yaml
@@ -3,7 +3,7 @@ version: "3"
 vars:
   NAMESPACE: inference-gateway
   UI_RELEASE: inference-gateway-ui
-  CHART_VERSION: 0.6.0
+  CHART_VERSION: 0.6.1-rc.1
 
 tasks:
   deploy-infrastructure:
@@ -99,6 +99,7 @@ tasks:
           --namespace {{.NAMESPACE}} \
           --set replicaCount=1 \
           --set gateway.enabled=true \
+          --set gateway.envFrom.secretRef=inference-gateway \
           --set-string env[0].name=NODE_ENV \
           --set-string env[0].value=production \
           --set-string env[1].name=NEXT_TELEMETRY_DISABLED \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inference-gateway-ui",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inference-gateway-ui",
-      "version": "0.6.0",
+      "version": "0.6.1-rc.1",
       "dependencies": {
         "@inference-gateway/sdk": "^0.4.0",
         "@radix-ui/react-accordion": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inference-gateway-ui",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

This fix ensures the renaming of the ENABLE_AUTH variable works properly.

Also I'm going to simplify the deployment process with some good configurable defaults.