### PR TITLE
refactor(auth): Standardize environment variables to AUTH_ prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ The application uses a Next.js API layer (`/app/api`) that proxies requests to t
 
 ### Authentication
 
-Authentication is optional and controlled by `ENABLE_AUTH` environment variable. When enabled, uses NextAuth.js with Keycloak provider support.
+Authentication is optional and controlled by `AUTH_ENABLE` environment variable. When enabled, uses NextAuth.js with OIDC provider support.
 
 ## Development Standards
 
@@ -93,7 +93,7 @@ Authentication is optional and controlled by `ENABLE_AUTH` environment variable.
 Key environment variables for development:
 
 - `INFERENCE_GATEWAY_URL` - Backend API URL (default: http://localhost:8080)
-- `ENABLE_AUTH` - Enable authentication (default: false)
+- `AUTH_ENABLE` - Enable authentication (default: false)
 - `LOG_LEVEL` - Logging level for both client and server-side code (default: 'debug' in development, 'info' in production)
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Examples:
 
 | Environment Variable           | Default Value           | Description                                |
 | ------------------------------ | ----------------------- | ------------------------------------------ |
-| ENABLE_AUTH                    | `false`                 | Enable authentication                      |
+| AUTH_ENABLE                    | `false`                 | Enable authentication                      |
 | SECURE_COOKIES                 | `false`                 | Use secure cookies (set to true for HTTPS) |
 | NEXTAUTH_URL                   | `http://localhost:3000` | URL of this application (for NextAuth)     |
 | NEXTAUTH_SECRET                | -                       | Secret used to encrypt session cookies     |
@@ -112,9 +112,9 @@ Examples:
 
 | Environment Variable | Default Value                            | Description            |
 | -------------------- | ---------------------------------------- | ---------------------- |
-| KEYCLOAK_ID          | `app-client`                             | Keycloak client ID     |
-| KEYCLOAK_SECRET      | -                                        | Keycloak client secret |
-| KEYCLOAK_ISSUER      | `http://localhost:8080/realms/app-realm` | Keycloak issuer URL    |
+| AUTH_OIDC_CLIENT_ID          | `app-client`                             | OIDC client ID     |
+| AUTH_OIDC_CLIENT_SECRET      | -                                        | OIDC client secret |
+| AUTH_OIDC_ISSUER      | `http://localhost:8080/realms/app-realm` | OIDC issuer URL    |
 
 ## Docker
 

--- a/app/api/v1/chat/completions/route.ts
+++ b/app/api/v1/chat/completions/route.ts
@@ -3,7 +3,7 @@ import logger from '@/lib/logger';
 import { NextResponse } from 'next/server';
 
 export async function POST(req: Request) {
-  const isAuthEnabled = process.env.ENABLE_AUTH === 'true';
+  const isAuthEnabled = process.env.AUTH_ENABLE === 'true';
   const session = isAuthEnabled ? await auth() : null;
 
   if (isAuthEnabled && !session) {

--- a/app/api/v1/mcp/tools/route.ts
+++ b/app/api/v1/mcp/tools/route.ts
@@ -5,7 +5,7 @@ import { ListToolsResponse } from '@/types/mcp';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const isAuthEnabled = process.env.ENABLE_AUTH === 'true';
+  const isAuthEnabled = process.env.AUTH_ENABLE === 'true';
   const session = isAuthEnabled ? await auth() : null;
 
   if (isAuthEnabled && !session) {

--- a/app/api/v1/models/route.ts
+++ b/app/api/v1/models/route.ts
@@ -4,7 +4,7 @@ import { InferenceGatewayClient } from '@inference-gateway/sdk';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const isAuthEnabled = process.env.ENABLE_AUTH === 'true';
+  const isAuthEnabled = process.env.AUTH_ENABLE === 'true';
   const session = isAuthEnabled ? await auth() : null;
 
   if (isAuthEnabled && !session) {

--- a/app/api/v1/storage/active-chat/route.ts
+++ b/app/api/v1/storage/active-chat/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   try {
     const session = await auth();
 
-    const enableAuth = process.env.ENABLE_AUTH === 'true';
+    const enableAuth = process.env.AUTH_ENABLE === 'true';
     if (enableAuth && !session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
   try {
     const session = await auth();
 
-    const enableAuth = process.env.ENABLE_AUTH === 'true';
+    const enableAuth = process.env.AUTH_ENABLE === 'true';
     if (enableAuth && !session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/v1/storage/chat-sessions/route.ts
+++ b/app/api/v1/storage/chat-sessions/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   try {
     const session = await auth();
 
-    const enableAuth = process.env.ENABLE_AUTH === 'true';
+    const enableAuth = process.env.AUTH_ENABLE === 'true';
     if (enableAuth && !session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
   try {
     const session = await auth();
 
-    const enableAuth = process.env.ENABLE_AUTH === 'true';
+    const enableAuth = process.env.AUTH_ENABLE === 'true';
     if (enableAuth && !session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/v1/storage/selected-model/route.ts
+++ b/app/api/v1/storage/selected-model/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   try {
     const session = await auth();
 
-    const enableAuth = process.env.ENABLE_AUTH === 'true';
+    const enableAuth = process.env.AUTH_ENABLE === 'true';
     if (enableAuth && !session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
   try {
     const session = await auth();
 
-    const enableAuth = process.env.ENABLE_AUTH === 'true';
+    const enableAuth = process.env.AUTH_ENABLE === 'true';
     if (enableAuth && !session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -7,7 +7,7 @@ import logger from '@/lib/logger';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
-  const isAuthEnabled = process.env.ENABLE_AUTH === 'true';
+  const isAuthEnabled = process.env.AUTH_ENABLE === 'true';
   if (!isAuthEnabled) {
     logger.debug('[Auth] Authentication is disabled, redirecting to chat');
     redirect('/chat');

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -7,7 +7,7 @@ import type { StorageConfig } from '@/types/chat';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
-  const isAuthEnabled = process.env.ENABLE_AUTH === 'true';
+  const isAuthEnabled = process.env.AUTH_ENABLE === 'true';
   const session = await auth();
 
   if (isAuthEnabled && !session) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const isAuthEnabled = process.env.ENABLE_AUTH === 'true';
+  const isAuthEnabled = process.env.AUTH_ENABLE === 'true';
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/charts/inference-gateway-ui/templates/configmap-defaults.yaml
+++ b/charts/inference-gateway-ui/templates/configmap-defaults.yaml
@@ -14,7 +14,7 @@ data:
   # Storage
   STORAGE_TYPE: {{ .Values.config.STORAGE_TYPE | quote }}
   # Authentication General Settings
-  ENABLE_AUTH: {{ .Values.config.ENABLE_AUTH | quote }}
+  AUTH_ENABLE: {{ .Values.config.AUTH_ENABLE | quote }}
   SECURE_COOKIES: {{ .Values.config.SECURE_COOKIES | quote }}
   NEXTAUTH_URL: {{ .Values.config.NEXTAUTH_URL | quote }}
   NEXTAUTH_TRUST_HOST: {{ .Values.config.NEXTAUTH_TRUST_HOST | quote }}

--- a/charts/inference-gateway-ui/templates/secret.yaml
+++ b/charts/inference-gateway-ui/templates/secret.yaml
@@ -8,7 +8,7 @@ metadata:
 stringData:
   # The salt for encypting the JWT token. Read more here: https://next-auth.js.org/configuration/options#nextauth_url
   NEXTAUTH_SECRET: "very-secret-change-me"
-  KEYCLOAK_ID: ""
-  KEYCLOAK_SECRET: ""
-  KEYCLOAK_ISSUER: ""
+  AUTH_OIDC_CLIENT_ID: ""
+  AUTH_OIDC_CLIENT_SECRET: ""
+  AUTH_OIDC_ISSUER: ""
 {{- end }}

--- a/charts/inference-gateway-ui/values.yaml
+++ b/charts/inference-gateway-ui/values.yaml
@@ -151,7 +151,7 @@ config:
   INFERENCE_GATEWAY_URL: "http://inference-gateway:8080"
   LOG_LEVEL: "info"
   # Authentication General Settings
-  ENABLE_AUTH: "true"
+  AUTH_ENABLE: "true"
   SECURE_COOKIES: "true"
   NEXTAUTH_URL: "http://localhost:3000"
   NEXTAUTH_TRUST_HOST: "true"

--- a/examples/docker-compose/authentication/.env.frontend.example
+++ b/examples/docker-compose/authentication/.env.frontend.example
@@ -9,7 +9,7 @@ STORAGE_TYPE=local
 # DB_CONNECTION_URL=postgresql://username:password@host:port/database
 
 # Authentication General Settings
-ENABLE_AUTH=true
+AUTH_ENABLE=true
 SECURE_COOKIES=false # Set to true if you are using HTTPS for production
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=very-secret
@@ -17,6 +17,6 @@ NEXTAUTH_TRUST_HOST=true
 NEXTAUTH_REFRESH_TOKEN_ENABLED=true
 
 # Setup Auth Providers
-KEYCLOAK_ID=app-client
-KEYCLOAK_SECRET=very-secret
-KEYCLOAK_ISSUER=http://localhost:8080/realms/app-realm
+AUTH_OIDC_CLIENT_ID=app-client
+AUTH_OIDC_CLIENT_SECRET=very-secret
+AUTH_OIDC_ISSUER=http://localhost:8080/realms/app-realm

--- a/examples/docker-compose/authentication/README.md
+++ b/examples/docker-compose/authentication/README.md
@@ -20,23 +20,23 @@ cp .env.frontend.example .env.frontend
 2. Configure backend environment (.env.backend):
 
 ```ini
-ENABLE_AUTH=true
+AUTH_ENABLE=true
 SECURE_COOKIES=false # Set to true if you are using HTTPS for production
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your-secure-random-salt
 NEXTAUTH_TRUST_HOST=true
 NEXTAUTH_REFRESH_TOKEN_ENABLED=true # Wether you want to use refresh tokens once the access token expires
 
-# Keycloak Configuration
-KEYCLOAK_ID=app-client
-KEYCLOAK_SECRET=very-secret
-KEYCLOAK_ISSUER=http://localhost:8080/realms/app-realm
+# OIDC Configuration
+AUTH_OIDC_CLIENT_ID=app-client
+AUTH_OIDC_CLIENT_SECRET=very-secret
+AUTH_OIDC_ISSUER=http://localhost:8080/realms/app-realm
 ```
 
 3. Configure frontend environment (.env.frontend):
 
 ```ini
-ENABLE_AUTH="true"
+AUTH_ENABLE="true"
 ```
 
 4. Start the services:

--- a/examples/docker-compose/basic/.env.frontend.example
+++ b/examples/docker-compose/basic/.env.frontend.example
@@ -11,11 +11,11 @@ STORAGE_TYPE=local
 # DB_CONNECTION_URL=postgresql://username:password@host:port/database
 
 # Authentication General settings
-ENABLE_AUTH=false
+AUTH_ENABLE=false
 # NEXTAUTH_URL=http://localhost:3000
 # NEXTAUTH_SECRET=
 
 # Authentication for providers
-# KEYCLOAK_ID=
-# KEYCLOAK_SECRET=
-# KEYCLOAK_ISSUER=
+# AUTH_OIDC_CLIENT_ID=
+# AUTH_OIDC_CLIENT_SECRET=
+# AUTH_OIDC_ISSUER=

--- a/examples/docker-compose/mcp/.env.frontend.example
+++ b/examples/docker-compose/mcp/.env.frontend.example
@@ -11,11 +11,11 @@ STORAGE_TYPE=local
 # DB_CONNECTION_URL=postgresql://username:password@host:port/database
 
 # Authentication General settings
-ENABLE_AUTH=false
+AUTH_ENABLE=false
 # NEXTAUTH_URL=http://localhost:3000
 # NEXTAUTH_SECRET=
 
 # Authentication for providers
-# KEYCLOAK_ID=
-# KEYCLOAK_SECRET=
-# KEYCLOAK_ISSUER=
+# AUTH_OIDC_CLIENT_ID=
+# AUTH_OIDC_CLIENT_SECRET=
+# AUTH_OIDC_ISSUER=

--- a/examples/docker-compose/postgres/.env.frontend.example
+++ b/examples/docker-compose/postgres/.env.frontend.example
@@ -23,7 +23,7 @@ DB_CONNECTION_TIMEOUT=2000
 INFERENCE_GATEWAY_URL=http://inference-gateway:8080
 
 # Authentication (set to true if using authentication)
-ENABLE_AUTH=false
+AUTH_ENABLE=false
 
 # Logging level (optional, defaults to 'debug' in development, 'info' in production)
 LOG_LEVEL=info

--- a/examples/docker-compose/postgres/README.md
+++ b/examples/docker-compose/postgres/README.md
@@ -60,7 +60,7 @@ DB_CONNECTION_TIMEOUT=2000
 
 # Other UI configuration
 INFERENCE_GATEWAY_URL=http://inference-gateway:8080
-ENABLE_AUTH=false
+AUTH_ENABLE=false
 ```
 
 ### Backend Environment Variables

--- a/examples/kubernetes/Taskfile.yaml
+++ b/examples/kubernetes/Taskfile.yaml
@@ -291,8 +291,8 @@ tasks:
         helm upgrade --install {{.UI_RELEASE}} oci://ghcr.io/inference-gateway/charts/inference-gateway-ui --version {{.CHART_VERSION}} \
           --create-namespace \
           --namespace {{.NAMESPACE}} \
-          --set config.ENABLE_AUTH=false \
-          --set gateway.config.ENABLE_AUTH=false
+          --set config.AUTH_ENABLE=false \
+          --set gateway.config.AUTH_ENABLE=false
 
   deploy-ui-only:
     desc: Deploy just the UI, connecting to existing Gateway
@@ -302,7 +302,7 @@ tasks:
         helm upgrade --install {{.UI_RELEASE}} oci://ghcr.io/inference-gateway/charts/inference-gateway-ui --version {{.CHART_VERSION}} \
           --create-namespace \
           --namespace {{.NAMESPACE}} \
-          --set config.ENABLE_AUTH=false \
+          --set config.AUTH_ENABLE=false \
           --set gateway.enabled=false
 
   deploy-with-ingress:
@@ -316,8 +316,8 @@ tasks:
           --set replicaCount=1 \
           --set gateway.envFrom.secretRef=inference-gateway \
           --set gateway.enabled=true \
-          --set gateway.config.ENABLE_AUTH=false \
-          --set config.ENABLE_AUTH=false \
+          --set gateway.config.AUTH_ENABLE=false \
+          --set config.AUTH_ENABLE=false \
           --set ingress.enabled=true \
           --set ingress.className=nginx \
           --set ingress.hosts[0].host=ui.inference-gateway.local \
@@ -374,9 +374,9 @@ tasks:
         type: Opaque
         stringData:
           NEXTAUTH_SECRET: dummy-secret
-          KEYCLOAK_ID: inference-gateway-client
-          KEYCLOAK_SECRET: very-secret
-          KEYCLOAK_ISSUER: https://keycloak.inference-gateway.local/realms/inference-gateway-realm
+          AUTH_OIDC_CLIENT_ID: inference-gateway-client
+          AUTH_OIDC_CLIENT_SECRET: very-secret
+          AUTH_OIDC_ISSUER: https://keycloak.inference-gateway.local/realms/inference-gateway-realm
         EOF
       - echo "Deploying UI with authentication..."
       - |

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -16,12 +16,12 @@ async function refreshAccessToken(token: JWT): Promise<JWT> {
   try {
     switch (token.provider) {
       case 'keycloak': {
-        const url = `${process.env.KEYCLOAK_ISSUER!}/protocol/openid-connect/token`;
+        const url = `${process.env.AUTH_OIDC_ISSUER!}/protocol/openid-connect/token`;
         logger.debug(`[Auth] Attempting to refresh Keycloak token at ${url}`);
 
         const params = {
-          client_id: process.env.KEYCLOAK_ID!,
-          client_secret: process.env.KEYCLOAK_SECRET!,
+          client_id: process.env.AUTH_OIDC_CLIENT_ID!,
+          client_secret: process.env.AUTH_OIDC_CLIENT_SECRET!,
           grant_type: 'refresh_token',
           refresh_token: token.refreshToken as string,
         };
@@ -169,10 +169,10 @@ export const authConfig: NextAuthConfig = {
     Keycloak({
       id: 'keycloak',
       name: 'Keycloak',
-      clientId: process.env.KEYCLOAK_ID!,
-      clientSecret: process.env.KEYCLOAK_SECRET!,
-      issuer: process.env.KEYCLOAK_ISSUER!,
-      wellKnown: `${process.env.KEYCLOAK_ISSUER!}/.well-known/openid-configuration`,
+      clientId: process.env.AUTH_OIDC_CLIENT_ID!,
+      clientSecret: process.env.AUTH_OIDC_CLIENT_SECRET!,
+      issuer: process.env.AUTH_OIDC_ISSUER!,
+      wellKnown: `${process.env.AUTH_OIDC_ISSUER!}/.well-known/openid-configuration`,
       authorization: {
         params: {
           scope: 'openid profile email roles',
@@ -314,7 +314,7 @@ type AuthHandlers = {
 };
 
 const createAuthHandlers = (): AuthHandlers => {
-  if (process.env.ENABLE_AUTH !== 'true') {
+  if (process.env.AUTH_ENABLE !== 'true') {
     return {
       GET: async () => new Response(null, { status: 404 }),
       POST: async () => new Response(null, { status: 404 }),
@@ -353,7 +353,7 @@ export function getEnabledProviders(): ProviderConfig[] {
       id: 'keycloak',
       name: 'Keycloak',
       enabled: Boolean(
-        process.env.KEYCLOAK_ID && process.env.KEYCLOAK_SECRET && process.env.KEYCLOAK_ISSUER
+        process.env.AUTH_OIDC_CLIENT_ID && process.env.AUTH_OIDC_CLIENT_SECRET && process.env.AUTH_OIDC_ISSUER
       ),
       signinUrl: `/api/auth/signin/keycloak`,
       callbackUrl: `/api/auth/callback/keycloak`,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -460,7 +460,7 @@ components:
       bearerFormat: JWT
       description: |
         Authentication is optional by default.
-        To enable authentication, set ENABLE_AUTH to true.
+        To enable authentication, set AUTH_ENABLE to true.
         When enabled, requests must include a valid JWT token in the Authorization header.
   schemas:
     Provider:
@@ -1243,7 +1243,7 @@ components:
                   default: 'false'
                   description: 'Enable telemetry'
                 - name: enable_auth
-                  env: 'ENABLE_AUTH'
+                  env: 'AUTH_ENABLE'
                   type: bool
                   default: 'false'
                   description: 'Enable authentication'

--- a/tests/api/v1/mcp/tools/route.test.ts
+++ b/tests/api/v1/mcp/tools/route.test.ts
@@ -33,13 +33,13 @@ describe('/api/v1/mcp/tools GET', () => {
   });
 
   afterEach(() => {
-    delete process.env.ENABLE_AUTH;
+    delete process.env.AUTH_ENABLE;
     delete process.env.INFERENCE_GATEWAY_URL;
   });
 
   describe('authentication', () => {
-    it('should require authentication when ENABLE_AUTH is true', async () => {
-      process.env.ENABLE_AUTH = 'true';
+    it('should require authentication when AUTH_ENABLE is true', async () => {
+      process.env.AUTH_ENABLE = 'true';
       mockAuth.mockResolvedValue(null);
 
       const response = await GET();
@@ -49,8 +49,8 @@ describe('/api/v1/mcp/tools GET', () => {
       expect(data.error).toBe('Unauthorized');
     });
 
-    it('should allow access when ENABLE_AUTH is false', async () => {
-      process.env.ENABLE_AUTH = 'false';
+    it('should allow access when AUTH_ENABLE is false', async () => {
+      process.env.AUTH_ENABLE = 'false';
       process.env.INFERENCE_GATEWAY_URL = 'http://localhost:8080';
 
       const mockTools: ListToolsResponse = {
@@ -87,7 +87,7 @@ describe('/api/v1/mcp/tools GET', () => {
     });
 
     it('should allow access when authenticated', async () => {
-      process.env.ENABLE_AUTH = 'true';
+      process.env.AUTH_ENABLE = 'true';
       process.env.INFERENCE_GATEWAY_URL = 'http://localhost:8080';
 
       const mockSession = {
@@ -132,7 +132,7 @@ describe('/api/v1/mcp/tools GET', () => {
 
   describe('gateway integration', () => {
     beforeEach(() => {
-      process.env.ENABLE_AUTH = 'false';
+      process.env.AUTH_ENABLE = 'false';
       process.env.INFERENCE_GATEWAY_URL = 'http://localhost:8080';
     });
 
@@ -216,7 +216,7 @@ describe('/api/v1/mcp/tools GET', () => {
     });
 
     it('should create client with proper authentication headers', async () => {
-      process.env.ENABLE_AUTH = 'true';
+      process.env.AUTH_ENABLE = 'true';
       const mockSession = {
         user: { email: 'test@example.com' },
         accessToken: 'test-token',
@@ -240,7 +240,7 @@ describe('/api/v1/mcp/tools GET', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      process.env.ENABLE_AUTH = 'false';
+      process.env.AUTH_ENABLE = 'false';
       process.env.INFERENCE_GATEWAY_URL = 'http://localhost:8080';
     });
 

--- a/tests/api/v1/storage/chat-sessions/route.test.ts
+++ b/tests/api/v1/storage/chat-sessions/route.test.ts
@@ -59,8 +59,8 @@ describe('/api/v1/storage/chat-sessions', () => {
       });
     });
 
-    it('should require authentication when ENABLE_AUTH is true', async () => {
-      process.env.ENABLE_AUTH = 'true';
+    it('should require authentication when AUTH_ENABLE is true', async () => {
+      process.env.AUTH_ENABLE = 'true';
       mockAuth.mockResolvedValue(null);
 
       const response = await GET();
@@ -70,8 +70,8 @@ describe('/api/v1/storage/chat-sessions', () => {
       expect(data.error).toBe('Unauthorized');
     });
 
-    it('should allow access when ENABLE_AUTH is false', async () => {
-      process.env.ENABLE_AUTH = 'false';
+    it('should allow access when AUTH_ENABLE is false', async () => {
+      process.env.AUTH_ENABLE = 'false';
       mockAuth.mockResolvedValue(null);
       mockStorageService.getChatSessions.mockResolvedValue([]);
 
@@ -114,8 +114,8 @@ describe('/api/v1/storage/chat-sessions', () => {
       expect(mockStorageService.saveChatSessions).toHaveBeenCalledWith(mockChatSessions);
     });
 
-    it('should require authentication when ENABLE_AUTH is true', async () => {
-      process.env.ENABLE_AUTH = 'true';
+    it('should require authentication when AUTH_ENABLE is true', async () => {
+      process.env.AUTH_ENABLE = 'true';
       mockAuth.mockResolvedValue(null);
 
       const mockRequest = {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -2,7 +2,7 @@ import 'next-auth';
 
 declare module 'next-auth' {
   /**
-   * Injected to the client's components when ENABLE_AUTH is true
+   * Injected to the client's components when AUTH_ENABLE is true
    */
   interface Session {
     user?: {


### PR DESCRIPTION
Resolves #59

This PR refactors authentication environment variables to:

- Use consistent AUTH_ prefix for all auth-related variables
- Make OIDC variables provider-agnostic (removing hardcoded KEYCLOAK naming)

## Environment Variable Changes
- `ENABLE_AUTH` → `AUTH_ENABLE`
- `KEYCLOAK_ID` → `AUTH_OIDC_CLIENT_ID`
- `KEYCLOAK_SECRET` → `AUTH_OIDC_CLIENT_SECRET`
- `KEYCLOAK_ISSUER` → `AUTH_OIDC_ISSUER`

## Files Updated
- 10 TypeScript/JavaScript application files
- 2 test files
- 3 Helm chart templates
- Documentation (README.md, CLAUDE.md)
- 4 .env.example files
- Kubernetes configuration files
- OpenAPI specification

## Verification
✅ All tests pass (193/193)
✅ No linting errors
✅ No type errors

Generated with [Claude Code](https://claude.ai/code)