### PR TITLE
refactor(tools): Refactor tool type detection to use prefix-based approach

### DIFF
--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -15,30 +15,28 @@ interface PageContent {
   error?: string;
 }
 
-const BUILTIN_TOOLS = ['web_search', 'fetch_page'];
-const A2A_TOOLS = ['query_a2a_agent_card', 'submit_task_to_agent'];
+// Note: BUILTIN_TOOLS kept for potential future use, currently not needed for prefix-based detection
+// const BUILTIN_TOOLS = ['web_search', 'fetch_page'];
 
 /**
  * Centralized function to detect if a tool is an A2A (Agent-to-Agent) tool
+ * Uses prefix-based detection for tools starting with "a2a_"
  * @param toolName - The name of the tool to check
  * @returns true if the tool is an A2A tool, false otherwise
  */
 export const isA2ATool = (toolName: string): boolean => {
-  return A2A_TOOLS.includes(toolName);
+  return toolName.startsWith('a2a_');
 };
 
 /**
  * Centralized function to detect if a tool is an MCP tool
+ * Uses prefix-based detection for tools starting with "mcp_"
  * @param toolName - The name of the tool to check
- * @param tools - Optional array of available tools
+ * @param tools - Optional array of available tools (deprecated, kept for backward compatibility)
  * @returns true if the tool is an MCP tool, false otherwise
  */
-export const isMCPTool = (toolName: string, tools?: SchemaChatCompletionTool[]): boolean => {
-  if (tools && tools.length > 0) {
-    return !tools.some(tool => tool.function.name === toolName);
-  }
-
-  return !BUILTIN_TOOLS.includes(toolName) && !A2A_TOOLS.includes(toolName);
+export const isMCPTool = (toolName: string, _tools?: SchemaChatCompletionTool[]): boolean => {
+  return toolName.startsWith('mcp_');
 };
 
 export const WebSearchTool: SchemaChatCompletionTool = {

--- a/tests/components/mcp-tool-components.test.tsx
+++ b/tests/components/mcp-tool-components.test.tsx
@@ -41,7 +41,7 @@ describe('Enhanced MCP Tool Components', () => {
         id: 'call_123',
         type: 'function' as ChatCompletionToolType,
         function: {
-          name: 'read_file',
+          name: 'mcp_read_file',
           arguments: JSON.stringify({ path: '/test/file.txt' }),
         },
       },
@@ -49,7 +49,7 @@ describe('Enhanced MCP Tool Components', () => {
         id: 'call_456',
         type: 'function' as ChatCompletionToolType,
         function: {
-          name: 'write_file',
+          name: 'mcp_write_file',
           arguments: JSON.stringify({
             path: '/test/output.txt',
             content: 'Hello World',
@@ -92,11 +92,11 @@ describe('Enhanced MCP Tool Components', () => {
       fireEvent.click(mainButton);
 
       await waitFor(() => {
-        expect(screen.getByText('read_file')).toBeInTheDocument();
-        expect(screen.getByText('write_file')).toBeInTheDocument();
+        expect(screen.getByText('mcp_read_file')).toBeInTheDocument();
+        expect(screen.getByText('mcp_write_file')).toBeInTheDocument();
       });
 
-      const readFileButton = screen.getByRole('button', { name: /read_file/ });
+      const readFileButton = screen.getByRole('button', { name: /mcp_read_file/ });
       fireEvent.click(readFileButton);
 
       await waitFor(() => {
@@ -165,22 +165,22 @@ describe('Enhanced MCP Tool Components', () => {
     });
 
     it('should display MCP tool response with correct formatting', async () => {
-      render(<ToolResponseBubble response={mockMCPResponse} toolName="read_file" />);
+      render(<ToolResponseBubble response={mockMCPResponse} toolName="mcp_read_file" />);
 
-      expect(screen.getByText(/read_file Response/)).toBeInTheDocument();
+      expect(screen.getByText(/mcp_read_file Response/)).toBeInTheDocument();
       expect(screen.getByText('MCP')).toBeInTheDocument();
       expect(screen.getByTestId('check-circle')).toBeInTheDocument();
     });
 
     it('should display MCP error response with error styling', async () => {
-      render(<ToolResponseBubble response={mockMCPErrorResponse} toolName="read_file" />);
+      render(<ToolResponseBubble response={mockMCPErrorResponse} toolName="mcp_read_file" />);
 
       expect(screen.getByText('Error')).toBeInTheDocument();
       expect(screen.getByTestId('x-circle')).toBeInTheDocument();
     });
 
     it('should expand and show detailed MCP response content', async () => {
-      render(<ToolResponseBubble response={mockMCPResponse} toolName="read_file" />);
+      render(<ToolResponseBubble response={mockMCPResponse} toolName="mcp_read_file" />);
 
       fireEvent.click(screen.getByRole('button'));
 
@@ -203,7 +203,7 @@ describe('Enhanced MCP Tool Components', () => {
 
     it('should handle plain text responses', async () => {
       const plainTextResponse = 'Simple text response';
-      render(<ToolResponseBubble response={plainTextResponse} toolName="read_file" />);
+      render(<ToolResponseBubble response={plainTextResponse} toolName="mcp_read_file" />);
 
       fireEvent.click(screen.getByRole('button'));
 
@@ -214,13 +214,13 @@ describe('Enhanced MCP Tool Components', () => {
 
     it('should handle malformed JSON gracefully', () => {
       const malformedResponse = '{ invalid json }';
-      render(<ToolResponseBubble response={malformedResponse} toolName="read_file" />);
+      render(<ToolResponseBubble response={malformedResponse} toolName="mcp_read_file" />);
 
-      expect(screen.getByText(/read_file Response/)).toBeInTheDocument();
+      expect(screen.getByText(/mcp_read_file Response/)).toBeInTheDocument();
     });
 
     it('should return null when no response provided', () => {
-      const { container } = render(<ToolResponseBubble response="" toolName="read_file" />);
+      const { container } = render(<ToolResponseBubble response="" toolName="mcp_read_file" />);
       expect(container.firstChild).toBeNull();
     });
   });

--- a/tests/components/tool-response-bubble.test.tsx
+++ b/tests/components/tool-response-bubble.test.tsx
@@ -5,22 +5,9 @@ jest.mock('@/components/code-block', () => ({
   CodeBlock: ({ children }: { children: string }) => <pre data-testid="code-block">{children}</pre>,
 }));
 
-jest.mock('@/lib/tools', () => ({
-  isMCPTool: jest.fn(),
-  isA2ATool: jest.fn(),
-}));
-
-import { isMCPTool, isA2ATool } from '@/lib/tools';
-
-const mockIsMCPTool = isMCPTool as jest.MockedFunction<typeof isMCPTool>;
-const mockIsA2ATool = isA2ATool as jest.MockedFunction<typeof isA2ATool>;
+// Note: Not mocking @/lib/tools anymore since we're using real prefix-based detection
 
 describe('ToolResponseBubble', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockIsMCPTool.mockReturnValue(false);
-    mockIsA2ATool.mockReturnValue(false);
-  });
 
   const jsonResponse = JSON.stringify({
     results: [
@@ -86,18 +73,13 @@ describe('ToolResponseBubble', () => {
   });
 
   describe('A2A Tools', () => {
-    beforeEach(() => {
-      mockIsA2ATool.mockReturnValue(true);
-      mockIsMCPTool.mockReturnValue(false);
-    });
-
     test('renders A2A tool badge and success message', () => {
       const a2aResponse = JSON.stringify({
         content: [{ type: 'text', text: 'Task completed successfully' }],
         isError: false,
       });
 
-      render(<ToolResponseBubble response={a2aResponse} toolName="submit_task_to_agent" />);
+      render(<ToolResponseBubble response={a2aResponse} toolName="a2a_submit_task_to_agent" />);
 
       expect(screen.getByText('A2A')).toBeInTheDocument();
 
@@ -111,7 +93,7 @@ describe('ToolResponseBubble', () => {
         isError: true,
       });
 
-      render(<ToolResponseBubble response={a2aErrorResponse} toolName="submit_task_to_agent" />);
+      render(<ToolResponseBubble response={a2aErrorResponse} toolName="a2a_submit_task_to_agent" />);
 
       const button = screen.getByRole('button');
       expect(button).toHaveClass('bg-red-50', 'border-red-200');
@@ -122,7 +104,7 @@ describe('ToolResponseBubble', () => {
     test('handles plain text A2A responses', () => {
       const plainTextResponse = 'Task completed successfully';
 
-      render(<ToolResponseBubble response={plainTextResponse} toolName="submit_task_to_agent" />);
+      render(<ToolResponseBubble response={plainTextResponse} toolName="a2a_submit_task_to_agent" />);
 
       fireEvent.click(screen.getByRole('button'));
       expect(screen.getByText('A2A Tool executed successfully')).toBeInTheDocument();
@@ -132,7 +114,7 @@ describe('ToolResponseBubble', () => {
     test('handles malformed A2A JSON responses', () => {
       const malformedResponse = 'invalid json {';
 
-      render(<ToolResponseBubble response={malformedResponse} toolName="submit_task_to_agent" />);
+      render(<ToolResponseBubble response={malformedResponse} toolName="a2a_submit_task_to_agent" />);
 
       fireEvent.click(screen.getByRole('button'));
       expect(screen.getByText('A2A Tool executed successfully')).toBeInTheDocument();
@@ -141,18 +123,13 @@ describe('ToolResponseBubble', () => {
   });
 
   describe('MCP Tools', () => {
-    beforeEach(() => {
-      mockIsA2ATool.mockReturnValue(false);
-      mockIsMCPTool.mockReturnValue(true);
-    });
-
     test('renders MCP tool badge and success message', () => {
       const mcpResponse = JSON.stringify({
         content: [{ type: 'text', text: 'MCP operation completed' }],
         isError: false,
       });
 
-      render(<ToolResponseBubble response={mcpResponse} toolName="mcp_tool" />);
+      render(<ToolResponseBubble response={mcpResponse} toolName="mcp_filesystem_read" />);
 
       expect(screen.getByText('MCP')).toBeInTheDocument();
 
@@ -166,7 +143,7 @@ describe('ToolResponseBubble', () => {
         isError: true,
       });
 
-      render(<ToolResponseBubble response={mcpErrorResponse} toolName="mcp_tool" />);
+      render(<ToolResponseBubble response={mcpErrorResponse} toolName="mcp_filesystem_read" />);
 
       const button = screen.getByRole('button');
       expect(button).toHaveClass('bg-red-50', 'border-red-200');
@@ -179,7 +156,7 @@ describe('ToolResponseBubble', () => {
         isError: false,
       });
 
-      render(<ToolResponseBubble response={mcpResponse} toolName="mcp_tool" />);
+      render(<ToolResponseBubble response={mcpResponse} toolName="mcp_filesystem_read" />);
 
       fireEvent.click(screen.getByRole('button'));
       expect(screen.getByText('MCP Tool executed successfully')).toBeInTheDocument();
@@ -188,7 +165,7 @@ describe('ToolResponseBubble', () => {
     test('handles plain text MCP responses', () => {
       const plainTextResponse = 'MCP operation completed';
 
-      render(<ToolResponseBubble response={plainTextResponse} toolName="mcp_tool" />);
+      render(<ToolResponseBubble response={plainTextResponse} toolName="mcp_filesystem_read" />);
 
       fireEvent.click(screen.getByRole('button'));
       expect(screen.getByText('MCP Tool executed successfully')).toBeInTheDocument();
@@ -198,27 +175,21 @@ describe('ToolResponseBubble', () => {
 
   describe('Response Formatting', () => {
     test('displays formatted JSON for complex responses', () => {
-      mockIsA2ATool.mockReturnValue(false);
-      mockIsMCPTool.mockReturnValue(true);
-
       const complexResponse = JSON.stringify({
         content: [{ type: 'text', text: '{"result": "complex data"}' }],
         isError: false,
       });
 
-      render(<ToolResponseBubble response={complexResponse} toolName="mcp_tool" />);
+      render(<ToolResponseBubble response={complexResponse} toolName="mcp_filesystem_read" />);
 
       fireEvent.click(screen.getByRole('button'));
       expect(screen.getByTestId('code-block')).toBeInTheDocument();
     });
 
     test('displays plain text for simple responses', () => {
-      mockIsA2ATool.mockReturnValue(true);
-      mockIsMCPTool.mockReturnValue(false);
-
       const simpleResponse = 'Simple text response';
 
-      render(<ToolResponseBubble response={simpleResponse} toolName="submit_task_to_agent" />);
+      render(<ToolResponseBubble response={simpleResponse} toolName="a2a_submit_task_to_agent" />);
 
       fireEvent.click(screen.getByRole('button'));
       expect(screen.queryByTestId('code-block')).not.toBeInTheDocument();

--- a/tests/lib/tools.test.ts
+++ b/tests/lib/tools.test.ts
@@ -1,0 +1,109 @@
+import { isA2ATool, isMCPTool } from '@/lib/tools';
+import { ChatCompletionToolType } from '@inference-gateway/sdk';
+
+describe('Tool Type Detection', () => {
+  describe('isA2ATool', () => {
+    test('should return true for tools with a2a_ prefix', () => {
+      expect(isA2ATool('a2a_query_agent_card')).toBe(true);
+      expect(isA2ATool('a2a_submit_task_to_agent')).toBe(true);
+      expect(isA2ATool('a2a_custom_tool')).toBe(true);
+    });
+
+    test('should return false for tools without a2a_ prefix', () => {
+      expect(isA2ATool('web_search')).toBe(false);
+      expect(isA2ATool('fetch_page')).toBe(false);
+      expect(isA2ATool('mcp_tool')).toBe(false);
+      expect(isA2ATool('regular_tool')).toBe(false);
+    });
+
+    test('should return false for empty or undefined tool names', () => {
+      expect(isA2ATool('')).toBe(false);
+      expect(isA2ATool('a2a')).toBe(false); // No underscore
+    });
+
+    test('should be case sensitive', () => {
+      expect(isA2ATool('A2A_tool')).toBe(false);
+      expect(isA2ATool('a2A_tool')).toBe(false);
+    });
+  });
+
+  describe('isMCPTool', () => {
+    test('should return true for tools with mcp_ prefix', () => {
+      expect(isMCPTool('mcp_filesystem_read')).toBe(true);
+      expect(isMCPTool('mcp_database_query')).toBe(true);
+      expect(isMCPTool('mcp_custom_action')).toBe(true);
+    });
+
+    test('should return false for tools without mcp_ prefix', () => {
+      expect(isMCPTool('web_search')).toBe(false);
+      expect(isMCPTool('fetch_page')).toBe(false);
+      expect(isMCPTool('a2a_tool')).toBe(false);
+      expect(isMCPTool('regular_tool')).toBe(false);
+    });
+
+    test('should return false for empty or undefined tool names', () => {
+      expect(isMCPTool('')).toBe(false);
+      expect(isMCPTool('mcp')).toBe(false); // No underscore
+    });
+
+    test('should be case sensitive', () => {
+      expect(isMCPTool('MCP_tool')).toBe(false);
+      expect(isMCPTool('mcP_tool')).toBe(false);
+    });
+
+    test('should ignore the tools parameter (deprecated)', () => {
+      const mockTools = [
+        {
+          type: 'function' as ChatCompletionToolType,
+          function: {
+            name: 'web_search',
+            description: 'Search the web',
+            parameters: {} as Record<string, never>,
+            strict: false,
+          },
+        },
+      ];
+
+      // Even if a tool is in the tools array, prefix detection takes precedence
+      expect(isMCPTool('mcp_custom_tool', mockTools)).toBe(true);
+      expect(isMCPTool('web_search', mockTools)).toBe(false);
+    });
+  });
+
+  describe('Integration Tests', () => {
+    test('should correctly identify different tool types', () => {
+      const testCases = [
+        { name: 'a2a_query_agent', expectedA2A: true, expectedMCP: false },
+        { name: 'mcp_filesystem_read', expectedA2A: false, expectedMCP: true },
+        { name: 'web_search', expectedA2A: false, expectedMCP: false },
+        { name: 'fetch_page', expectedA2A: false, expectedMCP: false },
+        { name: 'custom_tool', expectedA2A: false, expectedMCP: false },
+      ];
+
+      testCases.forEach(({ name, expectedA2A, expectedMCP }) => {
+        expect(isA2ATool(name)).toBe(expectedA2A);
+        expect(isMCPTool(name)).toBe(expectedMCP);
+      });
+    });
+
+    test('should handle edge cases', () => {
+      const edgeCases = [
+        'a2a_',
+        'mcp_',
+        '_a2a_tool',
+        '_mcp_tool',
+        'tool_a2a_suffix',
+        'tool_mcp_suffix',
+      ];
+
+      edgeCases.forEach(toolName => {
+        const isA2A = isA2ATool(toolName);
+        const isMCP = isMCPTool(toolName);
+        
+        // Only tools starting with the exact prefix should be detected
+        expect(isA2A).toBe(toolName.startsWith('a2a_'));
+        expect(isMCP).toBe(toolName.startsWith('mcp_'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Refactors tool type detection to use prefix-based detection instead of hardcoded arrays.

## Changes

- Updated `isA2ATool()` to detect tools with `a2a_` prefix
- Updated `isMCPTool()` to detect tools with `mcp_` prefix
- Added comprehensive tests for prefix-based detection
- Updated existing tests to use proper prefixed tool names
- Maintained backward compatibility with existing function signatures

## Benefits

- Automatic detection of any `a2a_*` or `mcp_*` prefixed tools
- No need to maintain hardcoded tool lists
- More scalable and maintainable approach
- Leverages recent Inference Gateway capabilities

Closes #73

Generated with [Claude Code](https://claude.ai/code)